### PR TITLE
Add discrete GameEngine

### DIFF
--- a/TowerForge/TowerForge.xcodeproj/project.pbxproj
+++ b/TowerForge/TowerForge.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		BAFFB9452BB0A8C800D8301F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFB9442BB0A8C800D8301F /* Constants.swift */; };
 		BAFFB9492BB0ABC400D8301F /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFB9482BB0ABC400D8301F /* Logger.swift */; };
 		BAFFB94B2BB11F9800D8301F /* GameEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFB94A2BB11F9800D8301F /* GameEngine.swift */; };
+		BAFFB9502BB12F9D00D8301F /* GameEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFB94F2BB12F9D00D8301F /* GameEngineTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -208,6 +209,7 @@
 		BAFFB9442BB0A8C800D8301F /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		BAFFB9482BB0ABC400D8301F /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		BAFFB94A2BB11F9800D8301F /* GameEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEngine.swift; sourceTree = "<group>"; };
+		BAFFB94F2BB12F9D00D8301F /* GameEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEngineTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -409,6 +411,7 @@
 		52DF5FC02BA32B2600135367 /* TowerForgeTests */ = {
 			isa = PBXGroup;
 			children = (
+				BAFFB94C2BB12F7D00D8301F /* GameModuleTests */,
 				BA443D402BAD9872009F0FFB /* EventTests */,
 				52DF5FE22BA3386400135367 /* CoreUITests */,
 				52DF5FC12BA32B2600135367 /* TowerForgeTests.swift */,
@@ -686,6 +689,14 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		BAFFB94C2BB12F7D00D8301F /* GameModuleTests */ = {
+			isa = PBXGroup;
+			children = (
+				BAFFB94F2BB12F9D00D8301F /* GameEngineTests.swift */,
+			);
+			path = GameModuleTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -925,6 +936,7 @@
 				52DF5FC22BA32B2600135367 /* TowerForgeTests.swift in Sources */,
 				BA443D472BB05C6E009F0FFB /* MoveEventTests.swift in Sources */,
 				52DF5FE42BA3391200135367 /* TFTexturesTests.swift in Sources */,
+				BAFFB9502BB12F9D00D8301F /* GameEngineTests.swift in Sources */,
 				BA443D4B2BB05F73009F0FFB /* RequestSpawnEventTests.swift in Sources */,
 				BA443D452BB05A3C009F0FFB /* SpawnEventTests.swift in Sources */,
 				BA443D492BB05EF0009F0FFB /* RemoveEventTests.swift in Sources */,
@@ -1102,7 +1114,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BPB6799M73;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TowerForge/Info.plist;
@@ -1137,7 +1149,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BPB6799M73;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TowerForge/Info.plist;

--- a/TowerForge/TowerForge.xcodeproj/project.pbxproj
+++ b/TowerForge/TowerForge.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		BA443D4B2BB05F73009F0FFB /* RequestSpawnEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA443D4A2BB05F73009F0FFB /* RequestSpawnEventTests.swift */; };
 		BAFFB9452BB0A8C800D8301F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFB9442BB0A8C800D8301F /* Constants.swift */; };
 		BAFFB9492BB0ABC400D8301F /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFB9482BB0ABC400D8301F /* Logger.swift */; };
+		BAFFB94B2BB11F9800D8301F /* GameEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFB94A2BB11F9800D8301F /* GameEngine.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -206,6 +207,7 @@
 		BABB7C052BA9A41000D54DAE /* TowerForceTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TowerForceTestPlan.xctestplan; sourceTree = "<group>"; };
 		BAFFB9442BB0A8C800D8301F /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		BAFFB9482BB0ABC400D8301F /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		BAFFB94A2BB11F9800D8301F /* GameEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEngine.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -544,6 +546,7 @@
 		BAFFB9332BB0A24400D8301F /* GameModule */ = {
 			isa = PBXGroup;
 			children = (
+				BAFFB94A2BB11F9800D8301F /* GameEngine.swift */,
 				3CCF9CB02BAB1BCE004D170E /* GameWorld.swift */,
 				3C99559F2BA47D3E00D33FA5 /* Entities */,
 				52DF5FF02BA3519D00135367 /* Components */,
@@ -883,6 +886,7 @@
 				3C9955BE2BA57E4B00D33FA5 /* EventManager.swift in Sources */,
 				3CE951562BACA0CF008B2785 /* Collidable.swift in Sources */,
 				52DF5FE62BA33AF300135367 /* TFSpriteNode.swift in Sources */,
+				BAFFB94B2BB11F9800D8301F /* GameEngine.swift in Sources */,
 				3C9955B42BA4B12000D33FA5 /* ArrowTower.swift in Sources */,
 				3CE951612BADE881008B2785 /* Spawnable.swift in Sources */,
 				52DF5FE92BA33F9700135367 /* Animatable.swift in Sources */,
@@ -1098,7 +1102,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = BPB6799M73;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TowerForge/Info.plist;
@@ -1133,7 +1137,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = BPB6799M73;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TowerForge/Info.plist;

--- a/TowerForge/TowerForge/GameModule/Entities/EntityManager.swift
+++ b/TowerForge/TowerForge/GameModule/Entities/EntityManager.swift
@@ -48,12 +48,9 @@ class EntityManager {
     /// Ensures that the UUID keys of entries in the dictionary match the UUID id of
     /// the associated values
     private func checkRepresentation() -> Bool {
-        for (key, value) in entitiesMap {
-            if key != entitiesMap[key]?.id {
+        for (key, _) in entitiesMap where key != entitiesMap[key]?.id {
                 return false
-            }
         }
-
         return true
     }
 }

--- a/TowerForge/TowerForge/GameModule/Entities/TFEntity.swift
+++ b/TowerForge/TowerForge/GameModule/Entities/TFEntity.swift
@@ -72,12 +72,9 @@ class TFEntity: Collidable {
     /// Ensures that the UUID keys of entries in the dictionary match the UUID id of
     /// the associated values
     private func checkRepresentation() -> Bool {
-        for (key, value) in components {
-            if key != components[key]?.id {
+        for (key, _) in components where key != components[key]?.id {
                 return false
-            }
         }
-
         return true
     }
 }

--- a/TowerForge/TowerForge/GameModule/GameEngine.swift
+++ b/TowerForge/TowerForge/GameModule/GameEngine.swift
@@ -15,7 +15,7 @@ import Foundation
 /// Where necessary, an appropriate GameEngine stub can be used to replace GameEngine
 /// wherever it is required.
 protocol AbstractGameEngine: EventTarget {
-    var entityManager: EntityManager { get set }
+    var entities: [TFEntity] { get }
 
     func updateGame(deltaTime: TimeInterval)
     func setUpSystems(with grid: Grid)
@@ -37,9 +37,12 @@ protocol AbstractGameEngine: EventTarget {
 /// A concrete implementation of the AbstractGameEngine protocol
 class GameEngine: AbstractGameEngine {
 
+    /// TODO: privatize these attributes after unit testing for private attibutes is sorted out
     var entityManager: EntityManager
     var systemManager: SystemManager
     var eventManager: EventManager
+
+    var entities: [TFEntity] { entityManager.entities }
 
     init(entityManager: EntityManager = EntityManager(),
          systemManager: SystemManager = SystemManager(),
@@ -47,13 +50,13 @@ class GameEngine: AbstractGameEngine {
         self.entityManager = entityManager
         self.systemManager = systemManager
         self.eventManager = eventManager
+        self.setupTeam()
+        self.setupPlayerInfo()
     }
 
     func updateGame(deltaTime: TimeInterval) {
         systemManager.update(deltaTime)
         eventManager.executeEvents(in: self)
-        self.setupTeam()
-        self.setupPlayerInfo()
     }
 
     func system<T: TFSystem>(ofType type: T.Type) -> T? {

--- a/TowerForge/TowerForge/GameModule/GameEngine.swift
+++ b/TowerForge/TowerForge/GameModule/GameEngine.swift
@@ -1,0 +1,113 @@
+//
+//  GameEngine.swift
+//  TowerForge
+//
+//  Created by Rubesh on 25/3/24.
+//
+
+import Foundation
+
+/// The AbstractGameEngine defines the interface specifications between any concrete
+/// implementation of a GameEngine and a client that requires a GameEngine. This is
+/// is line with both the Interface Segregation Principle and the Dependency Inversion
+/// Principle.
+///
+/// Where necessary, an appropriate GameEngine stub can be used to replace GameEngine
+/// wherever it is required.
+protocol AbstractGameEngine: EventTarget {
+    var entities: [TFEntity] { get }
+
+    func updateGame(deltaTime: TimeInterval)
+    func setUpSystems(with grid: Grid)
+
+    func contactDidBegin(between idA: UUID, and idB: UUID)
+    func contactDidEnd(between idA: UUID, and idB: UUID)
+
+    func addEntity(_ entity: TFEntity)
+    func addEvent(_ event: TFEvent)
+
+    func system<T: TFSystem>(ofType type: T.Type) -> T?
+}
+
+extension GameEngine {
+    func system<T: TFSystem>(ofType type: T.Type) -> T? {
+        systemManager.system(ofType: type)
+    }
+}
+
+/// A class that encapsulates handling of all Managers.
+///
+/// Currently, as per the ECS specification, this includes SystemManager,
+/// EntityManager, and EventManager.
+///
+/// A concrete implementation of the AbstractGameEngine protocol
+class GameEngine: AbstractGameEngine {
+    private var entityManager: EntityManager
+    private var systemManager: SystemManager
+    private var eventManager: EventManager
+
+    var entities: [TFEntity] {
+        entityManager.entities
+    }
+
+    init(entityManager: EntityManager = EntityManager(),
+         systemManager: SystemManager = SystemManager(),
+         eventManager: EventManager = EventManager()) {
+        self.entityManager = entityManager
+        self.systemManager = systemManager
+        self.eventManager = eventManager
+    }
+
+    func updateGame(deltaTime: TimeInterval) {
+        systemManager.update(deltaTime)
+        eventManager.executeEvents(in: self)
+        self.setupTeam()
+        self.setupPlayerInfo()
+    }
+
+    private func setupTeam() {
+        let ownTeam = Team(player: .ownPlayer)
+        let oppositeTeam = Team(player: .oppositePlayer)
+        entityManager.add(ownTeam)
+        entityManager.add(oppositeTeam)
+    }
+
+    private func setupPlayerInfo() {
+        let point = Point(initialPoint: 0)
+        entityManager.add(point)
+
+        let life = Life(initialLife: Team.lifeCount)
+        entityManager.add(life)
+    }
+
+    func setUpSystems(with grid: Grid) {
+        systemManager.add(system: HealthSystem(entityManager: entityManager, eventManager: eventManager))
+        systemManager.add(system: MovementSystem(entityManager: entityManager))
+        systemManager.add(system: RemoveSystem(entityManager: entityManager, eventManager: eventManager))
+        systemManager.add(system: SpawnSystem(entityManager: entityManager, eventManager: eventManager))
+        systemManager.add(system: ShootingSystem(entityManager: entityManager, eventManager: eventManager))
+        systemManager.add(system: AiSystem(entityManager: entityManager, eventManager: eventManager))
+        systemManager.add(system: ContactSystem(entityManager: entityManager, eventManager: eventManager))
+        systemManager.add(system: HomeSystem(entityManager: entityManager, eventManager: eventManager,
+                                             gridDelegate: grid))
+
+        // Temporary until we have different gamemodes
+        systemManager.system(ofType: AiSystem.self)?.aiPlayers.append(.oppositePlayer)
+    }
+
+    func contactDidBegin(between idA: UUID, and idB: UUID) {
+        systemManager.system(ofType: ContactSystem.self)?.insert(contact: TFContact(entityIdA: idA, entityIdB: idB))
+    }
+
+    func contactDidEnd(between idA: UUID, and idB: UUID) {
+        systemManager.system(ofType: ContactSystem.self)?.remove(contact: TFContact(entityIdA: idA, entityIdB: idB))
+    }
+
+    func addEntity(_ entity: TFEntity) {
+        entityManager.add(entity)
+    }
+
+    func addEvent(_ event: TFEvent) {
+        eventManager.add(event)
+    }
+}

--- a/TowerForge/TowerForge/GameModule/GameEngine.swift
+++ b/TowerForge/TowerForge/GameModule/GameEngine.swift
@@ -15,7 +15,7 @@ import Foundation
 /// Where necessary, an appropriate GameEngine stub can be used to replace GameEngine
 /// wherever it is required.
 protocol AbstractGameEngine: EventTarget {
-    var entities: [TFEntity] { get }
+    var entityManager: EntityManager { get set }
 
     func updateGame(deltaTime: TimeInterval)
     func setUpSystems(with grid: Grid)
@@ -29,12 +29,6 @@ protocol AbstractGameEngine: EventTarget {
     func system<T: TFSystem>(ofType type: T.Type) -> T?
 }
 
-extension GameEngine {
-    func system<T: TFSystem>(ofType type: T.Type) -> T? {
-        systemManager.system(ofType: type)
-    }
-}
-
 /// A class that encapsulates handling of all Managers.
 ///
 /// Currently, as per the ECS specification, this includes SystemManager,
@@ -42,13 +36,10 @@ extension GameEngine {
 ///
 /// A concrete implementation of the AbstractGameEngine protocol
 class GameEngine: AbstractGameEngine {
-    private var entityManager: EntityManager
-    private var systemManager: SystemManager
-    private var eventManager: EventManager
 
-    var entities: [TFEntity] {
-        entityManager.entities
-    }
+    var entityManager: EntityManager
+    var systemManager: SystemManager
+    var eventManager: EventManager
 
     init(entityManager: EntityManager = EntityManager(),
          systemManager: SystemManager = SystemManager(),
@@ -63,6 +54,10 @@ class GameEngine: AbstractGameEngine {
         eventManager.executeEvents(in: self)
         self.setupTeam()
         self.setupPlayerInfo()
+    }
+
+    func system<T: TFSystem>(ofType type: T.Type) -> T? {
+        systemManager.system(ofType: type)
     }
 
     private func setupTeam() {

--- a/TowerForge/TowerForge/GameModule/GameWorld.swift
+++ b/TowerForge/TowerForge/GameModule/GameWorld.swift
@@ -7,9 +7,9 @@
 
 import SpriteKit
 
-class GameWorld {
-    private unowned var scene: GameScene?
-    private var gameEngine: AbstractGameEngine
+class GameWorld: ObservableObject {
+    private weak var scene: GameScene?
+    private var gameEngine: GameEngine
     private var selectionNode: UnitSelectionNode
     private var grid: Grid
     private var renderer: Renderer?
@@ -31,6 +31,7 @@ class GameWorld {
     }
 
     func update(deltaTime: TimeInterval) {
+        DispatchQueue.main.async { self.objectWillChange.send() }
         gameEngine.updateGame(deltaTime: deltaTime)
         selectionNode.update()
         renderer?.render()
@@ -68,7 +69,8 @@ class GameWorld {
 
 extension GameWorld: Renderable {
     func entitiesToRender() -> [TFEntity] {
-        gameEngine.entities
+
+        gameEngine.entityManager.entities
     }
 }
 

--- a/TowerForge/TowerForge/GameModule/GameWorld.swift
+++ b/TowerForge/TowerForge/GameModule/GameWorld.swift
@@ -7,7 +7,7 @@
 
 import SpriteKit
 
-class GameWorld: ObservableObject {
+class GameWorld {
     private weak var scene: GameScene?
     private var gameEngine: GameEngine
     private var selectionNode: UnitSelectionNode
@@ -31,7 +31,6 @@ class GameWorld: ObservableObject {
     }
 
     func update(deltaTime: TimeInterval) {
-        DispatchQueue.main.async { self.objectWillChange.send() }
         gameEngine.updateGame(deltaTime: deltaTime)
         selectionNode.update()
         renderer?.render()
@@ -69,7 +68,7 @@ class GameWorld: ObservableObject {
 
 extension GameWorld: Renderable {
     func entitiesToRender() -> [TFEntity] {
-
+        
         gameEngine.entityManager.entities
     }
 }

--- a/TowerForge/TowerForge/GameModule/GameWorld.swift
+++ b/TowerForge/TowerForge/GameModule/GameWorld.swift
@@ -75,6 +75,6 @@ extension GameWorld: Renderable {
 extension GameWorld: UnitSelectionNodeDelegate {
     func unitSelectionNodeDidSpawn<T: TFEntity & PlayerSpawnable>(ofType type: T.Type, position: CGPoint) {
         gameEngine.addEvent(RequestSpawnEvent(ofType: type, timestamp: CACurrentMediaTime(),
-                                           position: position, player: .ownPlayer))
+                                              position: position, player: .ownPlayer))
     }
 }

--- a/TowerForge/TowerForge/GameModule/GameWorld.swift
+++ b/TowerForge/TowerForge/GameModule/GameWorld.swift
@@ -8,8 +8,8 @@
 import SpriteKit
 
 class GameWorld {
-    private weak var scene: GameScene?
-    private var gameEngine: GameEngine
+    private unowned var scene: GameScene?
+    private var gameEngine: AbstractGameEngine
     private var selectionNode: UnitSelectionNode
     private var grid: Grid
     private var renderer: Renderer?
@@ -68,8 +68,8 @@ class GameWorld {
 
 extension GameWorld: Renderable {
     func entitiesToRender() -> [TFEntity] {
-        
-        gameEngine.entityManager.entities
+
+        gameEngine.entities
     }
 }
 

--- a/TowerForge/TowerForge/GameModule/GameWorld.swift
+++ b/TowerForge/TowerForge/GameModule/GameWorld.swift
@@ -9,18 +9,14 @@ import SpriteKit
 
 class GameWorld {
     private unowned var scene: GameScene?
-    private var entityManager: EntityManager
-    private var systemManager: SystemManager
-    private var eventManager: EventManager
+    private var gameEngine: AbstractGameEngine
     private var selectionNode: UnitSelectionNode
     private var grid: Grid
     private var renderer: Renderer?
 
     init(scene: GameScene?, screenSize: CGRect) {
         self.scene = scene
-        entityManager = EntityManager()
-        systemManager = SystemManager()
-        eventManager = EventManager()
+        gameEngine = GameEngine()
         selectionNode = UnitSelectionNode()
 
         grid = Grid(screenSize: screenSize)
@@ -30,15 +26,12 @@ class GameWorld {
 
         renderer = Renderer(target: self, scene: scene)
         renderer?.renderMessage("Game Starts")
-        self.setUpSystems()
+        gameEngine.setUpSystems(with: grid)
         self.setUpSelectionNode()
-        self.setupTeam()
-        self.setupPlayerInfo()
     }
 
     func update(deltaTime: TimeInterval) {
-        systemManager.update(deltaTime)
-        eventManager.executeEvents(in: self)
+        gameEngine.updateGame(deltaTime: deltaTime)
         selectionNode.update()
         renderer?.render()
     }
@@ -46,40 +39,12 @@ class GameWorld {
         selectionNode.unitNodeDidSpawn(location)
     }
 
-    func setupTeam() {
-        let ownTeam = Team(player: .ownPlayer)
-        let oppositeTeam = Team(player: .oppositePlayer)
-        entityManager.add(ownTeam)
-        entityManager.add(oppositeTeam)
-    }
-    func setupPlayerInfo() {
-        let point = Point(initialPoint: 0)
-        entityManager.add(point)
-
-        let life = Life(initialLife: Team.lifeCount)
-        entityManager.add(life)
-    }
     func contactDidBegin(between idA: UUID, and idB: UUID) {
-        systemManager.system(ofType: ContactSystem.self)?.insert(contact: TFContact(entityIdA: idA, entityIdB: idB))
+        gameEngine.contactDidEnd(between: idA, and: idB)
     }
 
     func contactDidEnd(between idA: UUID, and idB: UUID) {
-        systemManager.system(ofType: ContactSystem.self)?.remove(contact: TFContact(entityIdA: idA, entityIdB: idB))
-    }
-
-    private func setUpSystems() {
-        systemManager.add(system: HealthSystem(entityManager: entityManager, eventManager: eventManager))
-        systemManager.add(system: MovementSystem(entityManager: entityManager))
-        systemManager.add(system: RemoveSystem(entityManager: entityManager, eventManager: eventManager))
-        systemManager.add(system: SpawnSystem(entityManager: entityManager, eventManager: eventManager))
-        systemManager.add(system: ShootingSystem(entityManager: entityManager, eventManager: eventManager))
-        systemManager.add(system: AiSystem(entityManager: entityManager, eventManager: eventManager))
-        systemManager.add(system: ContactSystem(entityManager: entityManager, eventManager: eventManager))
-        systemManager.add(system: HomeSystem(entityManager: entityManager, eventManager: eventManager,
-                                             gridDelegate: grid))
-
-        // Temporary until we have different gamemodes
-        systemManager.system(ofType: AiSystem.self)?.aiPlayers.append(.oppositePlayer)
+        gameEngine.contactDidEnd(between: idA, and: idB)
     }
 
     private func setUpSelectionNode() {
@@ -97,25 +62,19 @@ class GameWorld {
                                         y: 0)
             horizontalX += horizontalSpacing
         }
-        entityManager.add(selectionNode)
-    }
-}
-
-extension GameWorld: EventTarget {
-    func system<T: TFSystem>(ofType type: T.Type) -> T? {
-        systemManager.system(ofType: type)
+        gameEngine.addEntity(selectionNode)
     }
 }
 
 extension GameWorld: Renderable {
     func entitiesToRender() -> [TFEntity] {
-        entityManager.entities
+        gameEngine.entities
     }
 }
 
 extension GameWorld: UnitSelectionNodeDelegate {
     func unitSelectionNodeDidSpawn<T: TFEntity & PlayerSpawnable>(ofType type: T.Type, position: CGPoint) {
-        eventManager.add(RequestSpawnEvent(ofType: type, timestamp: CACurrentMediaTime(),
+        gameEngine.addEvent(RequestSpawnEvent(ofType: type, timestamp: CACurrentMediaTime(),
                                            position: position, player: .ownPlayer))
     }
 }

--- a/TowerForge/TowerForgeTests/EventTests/DamageEventTests.swift
+++ b/TowerForge/TowerForgeTests/EventTests/DamageEventTests.swift
@@ -4,14 +4,6 @@ import XCTest
 
 final class DamageEventTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
     func test_initializeDamageEvent() {
         let entityId = UUID()
         let timestamp = 1.0

--- a/TowerForge/TowerForgeTests/EventTests/MoveEventTests.swift
+++ b/TowerForge/TowerForgeTests/EventTests/MoveEventTests.swift
@@ -4,14 +4,6 @@ import XCTest
 
 final class MoveEventTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
     func test_initializeMoveEvent() {
         let entityId = UUID()
         let timestamp = 1.0

--- a/TowerForge/TowerForgeTests/EventTests/RemoveEventTests.swift
+++ b/TowerForge/TowerForgeTests/EventTests/RemoveEventTests.swift
@@ -4,14 +4,6 @@ import XCTest
 
 final class RemoveEventTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
     func test_initializeRemoveEvent() {
         let entityId = UUID()
         let timestamp = 1.0

--- a/TowerForge/TowerForgeTests/EventTests/RequestSpawnEventTests.swift
+++ b/TowerForge/TowerForgeTests/EventTests/RequestSpawnEventTests.swift
@@ -4,14 +4,6 @@ import XCTest
 
 final class RequestSpawnEventTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
     func test_initializeRequestSpawnEvent() {
         let timestamp = 1.0
         let entityType = MeleeUnit.self
@@ -30,7 +22,7 @@ final class RequestSpawnEventTests: XCTestCase {
 
         // MeleeUnit does not conform to equatable so XCAssertEqual cannot be used here
         XCTAssertTrue(requestSpawnEvent.entityType == entityType,
-                       "RequestSpawnEvent must have the same entity type as specified.")
+                      "RequestSpawnEvent must have the same entity type as specified.")
 
         // XCTAssertThrowsError(requestSpawnEvent.entityId, "Retrieving ID must throw fatal error")
 

--- a/TowerForge/TowerForgeTests/EventTests/SpawnEventTests.swift
+++ b/TowerForge/TowerForgeTests/EventTests/SpawnEventTests.swift
@@ -4,14 +4,6 @@ import XCTest
 
 final class SpawnEventTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
     func test_initializeSpawnEvent() {
         let entityId = UUID()
         let timestamp = 1.0
@@ -26,7 +18,8 @@ final class SpawnEventTests: XCTestCase {
                        "SpawnEvent must have the same timestamp as originally specified")
 
         XCTAssertEqual(spawnEvent.entity.id, spawnEvent.entityId,
-                       "Entity must have the same entityId as originally specified, both within the SpawnEvent and outside")
+                       "Entity must have the same entityId as originally specified"
+                       + "both within the SpawnEvent and outside")
     }
 
 }

--- a/TowerForge/TowerForgeTests/GameModuleTests/GameEngineTests.swift
+++ b/TowerForge/TowerForgeTests/GameModuleTests/GameEngineTests.swift
@@ -10,14 +10,6 @@ import XCTest
 
 final class GameEngineTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
     func test_initializeGameEngine() {
         let emptyEntityManager = EntityManager()
         let emptySystemManager = SystemManager()

--- a/TowerForge/TowerForgeTests/GameModuleTests/GameEngineTests.swift
+++ b/TowerForge/TowerForgeTests/GameModuleTests/GameEngineTests.swift
@@ -1,0 +1,44 @@
+//
+//  GameEngineTests.swift
+//  TowerForgeTests
+//
+//  Created by Rubesh on 25/3/24.
+//
+
+import XCTest
+@testable import TowerForge
+
+final class GameEngineTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func test_initializeGameEngine() {
+        let emptyEntityManager = EntityManager()
+        let emptySystemManager = SystemManager()
+        let emptyEventManager = EventManager()
+
+        // After adding the playerInfo and team components (2 each)
+        let entityCount = emptyEntityManager.entities.count + 4
+
+        let gameEngine = GameEngine()
+
+        XCTAssertEqual(gameEngine.entities.count,
+                       entityCount,
+                       "The GameEngine's entity manager must have the same count as the empty entity manager")
+
+        XCTAssertEqual(gameEngine.systemManager.systems.count,
+                       emptySystemManager.systems.count,
+                       "The GameEngine's system manager must have the same count as the empty system manager")
+
+        XCTAssertEqual(gameEngine.eventManager.eventQueue.count,
+                       emptyEventManager.eventQueue.count,
+                       "The GameEngine's event manager must have the same count as the empty event manager")
+    }
+
+}

--- a/TowerForge/TowerForgeTests/TowerForgeTests.swift
+++ b/TowerForge/TowerForgeTests/TowerForgeTests.swift
@@ -3,23 +3,8 @@ import XCTest
 
 final class TowerForgeTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class. 
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
+    /// Sample test to manually trigger CI/CD pipeline failure
     func testExample() throws {
         XCTAssertTrue(true)
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/TowerForge/TowerForgeUITests/TowerForgeUITests.swift
+++ b/TowerForge/TowerForgeUITests/TowerForgeUITests.swift
@@ -14,6 +14,7 @@ final class TowerForgeUITests: XCTestCase {
 
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
+        XCTAssertTrue(true)
     }
 
     func testExample() throws {


### PR DESCRIPTION
### Summary
- GameEngine extracted out from GameWorld
- GameEngine essentially encapsulates all the managers and encapsulates game updates.
- GameWorld remains conforming to Renderable, but GameEngine updated to conform to EventTarget

### Fixes
- Removed almost all SwiftLint errors (removed empty test cases)
- Fixed some styling issues here and there