### PR TITLE
[Patch] Change UUID to Type

### DIFF
--- a/TowerForge/TowerForge.xcodeproj/project.pbxproj
+++ b/TowerForge/TowerForge.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		9B8696552BAD759F0002377C /* Grid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8696542BAD759F0002377C /* Grid.swift */; };
 		9BC60BC82BB9BE6D001A6737 /* DisabledEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC60BC72BB9BE6D001A6737 /* DisabledEvent.swift */; };
 		9BD669682BAFDE5E00DC8C4C /* GridDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD669672BAFDE5E00DC8C4C /* GridDelegate.swift */; };
+		BA2F5ABB2BC4FD5900CBD8E9 /* EntityEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2F5ABA2BC4FD5900CBD8E9 /* EntityEnums.swift */; };
 		BA443D3D2BAD9557009F0FFB /* RemoveSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA443D3C2BAD9557009F0FFB /* RemoveSystem.swift */; };
 		BA443D3F2BAD9774009F0FFB /* RemoveEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA443D3E2BAD9774009F0FFB /* RemoveEvent.swift */; };
 		BA443D422BAD9885009F0FFB /* DamageEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA443D412BAD9885009F0FFB /* DamageEventTests.swift */; };
@@ -382,6 +383,7 @@
 		9B8696542BAD759F0002377C /* Grid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Grid.swift; sourceTree = "<group>"; };
 		9BC60BC72BB9BE6D001A6737 /* DisabledEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisabledEvent.swift; sourceTree = "<group>"; };
 		9BD669672BAFDE5E00DC8C4C /* GridDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridDelegate.swift; sourceTree = "<group>"; };
+		BA2F5ABA2BC4FD5900CBD8E9 /* EntityEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityEnums.swift; sourceTree = "<group>"; };
 		BA443D3C2BAD9557009F0FFB /* RemoveSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveSystem.swift; sourceTree = "<group>"; };
 		BA443D3E2BAD9774009F0FFB /* RemoveEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveEvent.swift; sourceTree = "<group>"; };
 		BA443D412BAD9885009F0FFB /* DamageEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DamageEventTests.swift; sourceTree = "<group>"; };
@@ -1046,6 +1048,7 @@
 			children = (
 				BAFFB95C2BB978E500D8301F /* StorageEnums.swift */,
 				BAFFB9842BBDBA7D00D8301F /* MediaEnums.swift */,
+				BA2F5ABA2BC4FD5900CBD8E9 /* EntityEnums.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1463,6 +1466,7 @@
 				527A07742BB3D8E800CD9D08 /* GameModeFactory.swift in Sources */,
 				5240D0AF2BB3B415004F1486 /* LifeEvent.swift in Sources */,
 				5295A2072BAA02FD005018A8 /* TFButtonNode.swift in Sources */,
+				BA2F5ABB2BC4FD5900CBD8E9 /* EntityEnums.swift in Sources */,
 				BAFFB96A2BB9A64000D8301F /* ObjectSet.swift in Sources */,
 				3CD37AA32BBEC0F900222D8A /* FirebaseRemoteEventPublisher.swift in Sources */,
 				3CAC4A6B2BB6992F00A5D22E /* TFNode.swift in Sources */,

--- a/TowerForge/TowerForge/Commons/Enums/EntityEnums.swift
+++ b/TowerForge/TowerForge/Commons/Enums/EntityEnums.swift
@@ -10,7 +10,7 @@ import Foundation
 typealias TFEntityType = EntityEnums.TFEntityType
 typealias TFComponentType = EntityEnums.TFComponentType
 class EntityEnums {
-    
+
     enum TFEntityType: String, Codable, CaseIterable {
         case TFEntity
         case BaseTower
@@ -29,7 +29,7 @@ class EntityEnums {
         case Timer
         case WizardBall
     }
-    
+
     enum TFComponentType: String, Codable, CaseIterable {
         case TFComponent
         case PlayerComponent
@@ -43,5 +43,7 @@ class EntityEnums {
         case LabelComponent
         case ButtonComponent
         case TimerComponent
+        case ContactComponent
+        case ShootingComponent
     }
 }

--- a/TowerForge/TowerForge/Commons/Enums/EntityEnums.swift
+++ b/TowerForge/TowerForge/Commons/Enums/EntityEnums.swift
@@ -1,0 +1,47 @@
+//
+//  EntityEnums.swift
+//  TowerForge
+//
+//  Created by Rubesh on 9/4/24.
+//
+
+import Foundation
+
+typealias TFEntityType = EntityEnums.TFEntityType
+typealias TFComponentType = EntityEnums.TFComponentType
+class EntityEnums {
+    
+    enum TFEntityType: String, Codable, CaseIterable {
+        case TFEntity
+        case BaseTower
+        case BaseUnit
+        case BaseProjectile
+        case Spawnable
+        case MeleeUnit
+        case SoldierUnit
+        case ArrowTower
+        case WizardUnit
+        case Team
+        case Bullet
+        case Point
+        case Life
+        case Death
+        case Timer
+        case WizardBall
+    }
+    
+    enum TFComponentType: String, Codable, CaseIterable {
+        case TFComponent
+        case PlayerComponent
+        case AiComponent
+        case HomeComponent
+        case DamageComponent
+        case HealthComponent
+        case SpriteComponent
+        case MovableComponent
+        case PositionComponent
+        case LabelComponent
+        case ButtonComponent
+        case TimerComponent
+    }
+}

--- a/TowerForge/TowerForge/GameModule/Components/BaseComponents/ButtonComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/BaseComponents/ButtonComponent.swift
@@ -11,6 +11,7 @@ class ButtonComponent: TFComponent {
     var size: CGSize
     var onTouch: TFButtonDelegate?
     var userInteracterable = true
+    override var componentType: TFComponentType { .ButtonComponent }
 
     init(size: CGSize, buttonDelegate: TFButtonDelegate? = nil) {
         self.size = size

--- a/TowerForge/TowerForge/GameModule/Components/BaseComponents/LabelComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/BaseComponents/LabelComponent.swift
@@ -17,6 +17,7 @@ class LabelComponent: TFComponent {
     var displacement: CGVector = .zero
     var horizontalAlignment: AlignmentMode = .center
     var verticalAlignment: AlignmentMode = .center
+    override var componentType: TFComponentType { .LabelComponent }
 
     init(text: String, name: String) {
         self.text = text

--- a/TowerForge/TowerForge/GameModule/Components/BaseComponents/MovableComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/BaseComponents/MovableComponent.swift
@@ -11,6 +11,7 @@ import CoreGraphics
 class MovableComponent: TFComponent {
     var velocity: CGVector
     var shouldMove = true
+    override var componentType: TFComponentType { .MovableComponent }
 
     init(velocity: CGVector = .zero) {
         self.velocity = velocity

--- a/TowerForge/TowerForge/GameModule/Components/BaseComponents/PositionComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/BaseComponents/PositionComponent.swift
@@ -10,6 +10,7 @@ import CoreGraphics
 import UIKit
 
 class PositionComponent: TFComponent {
+    override var componentType: TFComponentType { .PositionComponent }
     private(set) var position: CGPoint
     var anchorPoint: CGPoint
 

--- a/TowerForge/TowerForge/GameModule/Components/BaseComponents/SpriteComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/BaseComponents/SpriteComponent.swift
@@ -13,6 +13,7 @@ class SpriteComponent: TFComponent {
     var animatableKey: String
     var alpha = 1.0
     var staticOnScreen = false
+    override var componentType: TFComponentType { .SpriteComponent }
 
     init(textureNames: [String], size: CGSize, animatableKey: String) {
         self.textures = TFTextures(textureNames: textureNames, textureAtlasName: "Sprites")

--- a/TowerForge/TowerForge/GameModule/Components/BaseComponents/TimerComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/BaseComponents/TimerComponent.swift
@@ -9,6 +9,7 @@ import Foundation
 
 class TimerComponent: TFComponent {
     var time: TimeInterval
+    override var componentType: TFComponentType { .TimerComponent }
     init(timeLength: TimeInterval) {
         self.time = timeLength
         super.init()

--- a/TowerForge/TowerForge/GameModule/Components/GameComponents/ContactComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/GameComponents/ContactComponent.swift
@@ -9,6 +9,7 @@ import Foundation
 
 class ContactComponent: TFComponent {
     let hitboxSize: CGSize
+    override var componentType: TFComponentType { .ContactComponent }
 
     init(hitboxSize: CGSize) {
         self.hitboxSize = hitboxSize

--- a/TowerForge/TowerForge/GameModule/Components/GameComponents/DamageComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/GameComponents/DamageComponent.swift
@@ -12,6 +12,7 @@ class DamageComponent: TFComponent {
     private var lastAttackTime = TimeInterval(0)
     private let temporary: Bool
     let attackPower: CGFloat
+    override var componentType: TFComponentType { .DamageComponent }
 
     init(attackRate: TimeInterval, attackPower: CGFloat, temporary: Bool) {
         self.attackRate = attackRate

--- a/TowerForge/TowerForge/GameModule/Components/GameComponents/HealthComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/GameComponents/HealthComponent.swift
@@ -8,6 +8,7 @@
 import SpriteKit
 
 class HealthComponent: TFComponent {
+    override var componentType: TFComponentType { .HealthComponent }
     var currentHealth: CGFloat
     var maxHealth: CGFloat
     var isZero: Bool {

--- a/TowerForge/TowerForge/GameModule/Components/GameComponents/ShootingComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/GameComponents/ShootingComponent.swift
@@ -13,6 +13,7 @@ class ShootingComponent: TFComponent {
     private(set) var lastShotTime = TimeInterval(0)
     let attackPower: CGFloat
     let shootingType: BaseProjectile.Type
+    override var componentType: TFComponentType { .ShootingComponent }
 
     init(fireRate: TimeInterval, range: CGFloat, attackPower: CGFloat, shootingType: BaseProjectile.Type) {
         self.fireRate = fireRate

--- a/TowerForge/TowerForge/GameModule/Components/LevelComponents/AiComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/LevelComponents/AiComponent.swift
@@ -11,6 +11,7 @@ import UIKit
 class AiComponent: TFComponent {
     private var spawnableEntities: [(TFEntity & PlayerSpawnable).Type]
     private(set) var delayUnitNextSpawn: TimeInterval
+    override var componentType: TFComponentType { .AiComponent }
 
     var chosenUnit: (TFEntity & PlayerSpawnable).Type? {
         spawnableEntities.randomElement()

--- a/TowerForge/TowerForge/GameModule/Components/LevelComponents/HomeComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/LevelComponents/HomeComponent.swift
@@ -8,6 +8,7 @@
 import QuartzCore
 
 class HomeComponent: TFComponent {
+    override var componentType: TFComponentType { .HomeComponent }
     var lifeLeft: Int {
         didSet {
             // Update the life left in the LabelComponent when it changes
@@ -42,11 +43,13 @@ class HomeComponent: TFComponent {
     private var lastPointIncrease = TimeInterval(0)
     private var pointInterval: TimeInterval
     private var pointsPerInterval: Int = 1
+
     init(initialLifeCount: Int, pointInterval: TimeInterval) {
         self.lifeLeft = initialLifeCount
         self.pointInterval = pointInterval
         super.init()
     }
+
     func decreaseLife(by amount: Int) -> Int {
         self.lifeLeft -= amount
         return self.lifeLeft

--- a/TowerForge/TowerForge/GameModule/Components/LevelComponents/PlayerComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/LevelComponents/PlayerComponent.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class PlayerComponent: TFComponent {
     var player: Player
-    override var componentType: TFComponentType { .PlayerComponent }
+    var componentType: TFComponentType { .PlayerComponent }
     init(player: Player) {
         self.player = player
         super.init()

--- a/TowerForge/TowerForge/GameModule/Components/LevelComponents/PlayerComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/LevelComponents/PlayerComponent.swift
@@ -9,6 +9,7 @@ import Foundation
 
 class PlayerComponent: TFComponent {
     var player: Player
+    override var componentType: TFComponentType { .PlayerComponent }
     init(player: Player) {
         self.player = player
         super.init()

--- a/TowerForge/TowerForge/GameModule/Components/TFComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/TFComponent.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 class TFComponent: Identifiable {
+    var componentType: TFComponentType { .TFComponent }
     var id = UUID()
     weak var entity: TFEntity?
-    var componentType: TFComponentType { .TFComponent }
 
     init() {
         // No initialisation logic needed as of now

--- a/TowerForge/TowerForge/GameModule/Components/TFComponent.swift
+++ b/TowerForge/TowerForge/GameModule/Components/TFComponent.swift
@@ -10,6 +10,7 @@ import Foundation
 class TFComponent: Identifiable {
     var id = UUID()
     weak var entity: TFEntity?
+    var componentType: TFComponentType { .TFComponent }
 
     init() {
         // No initialisation logic needed as of now


### PR DESCRIPTION
### Summary

- Currently UUID is used to differentiate between entities' components
- This patch follows the Storage type enum, ensures that a specific component of an entity can be accessed directly